### PR TITLE
Update Link to sync with changes in Pandoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ module.exports = {
 	LineBreak: elt('LineBreak',0),
 	Formula: elt('Math',2), // don't conflict with js builtin Math
 	RawInline: elt('RawInline',2),
-	Link: elt('Link',2),
+	Link: elt('Link',3),
 	Image: elt('Image',3),
 	Note: elt('Note',1),
 	Span: elt('Span',2),


### PR DESCRIPTION
Since 1.16, Link takes three arguments in addition to Image taking 3 arguments. See http://hackage.haskell.org/package/pandoc-types-1.16.1/docs/Text-Pandoc-Definition.html#t:Inline