### PR TITLE
Move @types/node to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"pandocfilter"
 	],
 	"devDependencies": {
+		"@types/node": "^13.13.0",
 		"mocha": "7.1.1",
 		"request": "^2.88.2",
 		"request-promise-native": "^1.0.5",
@@ -28,7 +29,6 @@
 		"typescript": "^3.8.3"
 	},
 	"dependencies": {
-		"@types/node": "^13.13.0",
 		"get-stdin": "~7.0.0"
 	},
 	"prettier": {


### PR DESCRIPTION
This moves `@types/node` from `dependencies` to `devDependencies`, as it's not needed by consumers.