### PR TITLE
Export `elt` function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -350,7 +350,7 @@ type WrapArray<T> = T extends undefined
 	: [T];
 
 // Utility for creating constructor functions
-function elt<T extends EltType>(
+export function elt<T extends EltType>(
 	eltType: T,
 	numargs: number,
 ): (...args: WrapArray<EltMap[T]>) => Elt<T> {


### PR DESCRIPTION
The Python module [`pandocfilters`](https://github.com/jgm/pandocfilters) exports the `elt` function: https://github.com/jgm/pandocfilters/blob/06f4db99548a129c3ee8ac667436cb51a80c0f58/pandocfilters.py#L253

Used e.g. here: https://togithub.com/jgm/pandoc/issues/1023#issuecomment-656769330

This PR does the same for the TS/JS module.